### PR TITLE
UPI concept

### DIFF
--- a/payto.go
+++ b/payto.go
@@ -1,0 +1,78 @@
+package main
+
+import "net/url"
+
+/**
+  Applications MUST accept URIs with options in any order.  The
+   "amount" option MUST NOT occur more than once.  Other options MAY be
+   allowed multiple times, with further restrictions depending on the
+   payment target type.  The following options SHOULD be understood by
+   every payment target type.
+
+   amount:  The amount to transfer.  The format MUST be:
+
+        amount = currency ":" unit [ "." fraction ]
+        currency = 1*ALPHA
+        unit = 1*(DIGIT / ",")
+        fraction = 1*(DIGIT / ",")
+
+      If a 3-letter 'currency' is used, it MUST be an [ISO4217]
+      alphabetic code.  A payment target type MAY define semantics
+      beyond ISO 4217 for currency codes that are not 3 characters.  The
+      'unit' value MUST be smaller than 2^53.  If present, the
+      'fraction' MUST consist of no more than 8 decimal digits.  The use
+      of commas is optional for readability, and they MUST be ignored.
+
+   receiver-name:  Name of the entity that receives the payment
+      (creditor).  The value of this option MAY be subject to lossy
+      conversion, modification, and truncation (for example, due to line
+      wrapping or character set conversion).
+
+   sender-name:  Name of the entity that makes the payment (debtor).
+      The value of this option MAY be subject to lossy conversion,
+      modification, and truncation (for example, due to line wrapping or
+      character set conversion).
+
+   message:  A short message to identify the purpose of the payment.
+      The value of this option MAY be subject to lossy conversion,
+      modification, and truncation (for example, due to line wrapping or
+      character set conversion).
+
+   instruction:  A short message giving payment reconciliation
+      instructions to the recipient.  An instruction that follows the
+      character set and length limitation defined by the respective
+      payment target type SHOULD NOT be subject to lossy conversion.
+*/
+
+const (
+	InternationalBankAccountNumber = "iban"
+	AutomatedClearingHouse         = "ach"
+	UnifiedPaymentInterface        = "upi"
+	Bitcoin                        = "bitcoin"
+	InterledgerProtocol            = "ilp"
+	Void                           = "void"
+)
+
+type Payto interface {
+	Amount() string
+	// receiver-name (creditor)
+	ReceiverName() string
+	// sender-name (debitor)
+	SenderName() string
+	// A short message to identify the purpose of the payment.
+	Message() string
+	// A short message giving payment reconciliation instructions to the recipient.
+	Instruction() string
+	/**
+	  payto-URI = "payto://" authority path-abempty [ "?" opts ]
+	  opts = opt *( "&" opt )
+	  opt-name = generic-opt / authority-specific-opt
+	  opt-value = *pchar
+	  opt = opt-name "=" opt-value
+	  generic-opt = "amount" / "receiver-name" / "sender-name" /
+	                "message" / "instruction"
+	  authority-specific-opt = ALPHA *( ALPHA / DIGIT / "-" / "." )
+	  authority = ALPHA *( ALPHA / DIGIT / "-" / "." )
+	*/
+	URL() url.URL
+}

--- a/upi.go
+++ b/upi.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"math/big"
+	"net/url"
+)
+
+/**
+Name:  upi
+
+   Description:  Unified Payment Interface (UPI).  The path is an
+      account alias.  The amount and receiver-name options are mandatory
+      for this payment target.  Limitations on the length and character
+      set of option values are defined by the implementation of the
+      handler.  Language tags and internationalization of options are
+      not supported.
+
+   Example:
+      payto://upi/alice@example.com?receiver-name=Alice&amount=INR:200
+*/
+
+type UPI struct {
+	authority    string
+	accountAlias string
+	amount       big.Float
+	receiver     string
+
+	//optional fields
+	sender      string
+	message     string
+	instruction string
+}
+
+func NewUPI(accountAlias, receiver string, amount string) (UPI, error) {
+	floatAmount, succeeded := new(big.Float).SetString(amount)
+	if !succeeded {
+		return UPI{}, errors.New("")
+	}
+	return UPI{
+		authority:    UnifiedPaymentInterface,
+		accountAlias: accountAlias,
+		receiver:     receiver,
+		amount:       *floatAmount,
+	}, nil
+}
+
+func (U UPI) Amount() string {
+	return U.amount.String()
+}
+
+func (U UPI) ReceiverName() string {
+	return U.receiver
+}
+
+func (U UPI) SenderName() string {
+	return U.sender
+}
+
+func (U UPI) Message() string {
+	return U.message
+}
+
+func (U UPI) Instruction() string {
+	return U.instruction
+}
+
+func (U UPI) URL() string {
+	values := url.Values{}
+	values.Set("receiver-name", U.receiver)
+	values.Set("amount", U.amount.String())
+	if U.sender != "" {
+		values.Set("sender-name", U.sender)
+	}
+	encodeValues := values.Encode()
+	u := &url.URL{
+		Scheme:   "payto",
+		Host:     UnifiedPaymentInterface,
+		Path:     U.accountAlias,
+		RawQuery: encodeValues,
+	}
+	return u.String()
+}

--- a/upi_test.go
+++ b/upi_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewUPI(t *testing.T) {
+	tests := []struct {
+		name      string
+		UPI       UPI
+		wantedURL string
+	}{
+		{
+			name:      "should create a valid UPI wth the mandatory options ",
+			UPI:       createNewUPI(t, "my-lil-acc@payto.com", "the-receiver", "123.39"),
+			wantedURL: "payto://upi/my-lil-acc@payto.com?amount=123.39&receiver-name=the-receiver",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.UPI.URL(), tt.wantedURL) {
+				t.Errorf("NewUPI() got = %v, want %v", tt.UPI.URL(), tt.wantedURL)
+			}
+		})
+	}
+}
+
+func createNewUPI(t *testing.T, accountAlias, receiver, amount string) UPI {
+	t.Helper()
+	upi, err := NewUPI(accountAlias, receiver, amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return upi
+}


### PR DESCRIPTION
Name:  upi

   Description:  Unified Payment Interface (UPI).  The path is an
      account alias.  The amount and receiver-name options are mandatory
      for this payment target.  Limitations on the length and character
      set of option values are defined by the implementation of the
      handler.  Language tags and internationalization of options are
      not supported.

   Example:
      payto://upi/alice@example.com?receiver-name=Alice&amount=INR:200